### PR TITLE
removed gluon-next-node

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -14,7 +14,6 @@ GLUON_SITE_PACKAGES := \
 	gluon-luci-portconfig \
 	gluon-luci-private-wifi \
 	gluon-luci-wifi-config \
-	gluon-next-node \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-respondd \


### PR DESCRIPTION
This removes gloun-next-node like we talked about in issue #4 .
Please review as this closes #4