### PR TITLE
Map to choose coordinates in Config Mode

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -115,8 +115,8 @@
 			show_altitude = false,
 			osm = {
       				center = {
-        				lat = 52.951947558,
-        				lon = 8.744238281,
+        				lat = 52.407606260,
+        				lon = 9.623840771,
                     },
                         zoom = 13,
                     },

--- a/site.conf
+++ b/site.conf
@@ -115,10 +115,10 @@
 			show_altitude = false,
 			osm = {
       				center = {
-        				lat = 52.407606260,
-        				lon = 9.623840771,
+        				lat = 52.400000,
+        				lon = 9.600000,
                     },
-                        zoom = 13,
+                        zoom = 10,
                     },
 
 		},

--- a/site.conf
+++ b/site.conf
@@ -113,6 +113,14 @@
 	config_mode = {
 		geo_location = {
 			show_altitude = false,
+			osm = {
+      				center = {
+        				lat = 52.951947558,
+        				lon = 8.744238281,
+                    },
+                        zoom = 13,
+                    },
+
 		},
 		remote_login = {
 			show_password_form = true,

--- a/site.mk
+++ b/site.mk
@@ -5,6 +5,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-config-mode-contact-info \
 	gluon-config-mode-core \
 	gluon-config-mode-geo-location \
+	gluon-config-mode-geo-location-osm \
 	gluon-config-mode-hostname \
 	gluon-config-mode-mesh-vpn \
 	gluon-config-mode-domain-select \


### PR DESCRIPTION
I added the configs required for the Gluon OSM Map module to show a map in Config Mode for choosing the device coordinates. It's in Gluon since the 2018.2 release.
As far as i can tell it needs only 2KB in Flash.
It will load the Map as long as the PC, from which you configure the Router, has an active Interner connection. If doesn't have an internet connection it will look like before without the map, no error message.

Looks initial like this:
![karte](https://user-images.githubusercontent.com/43337106/51032183-62052b00-159f-11e9-849b-fd0f8d5bd58f.PNG)
