### PR TITLE
pr_wireguard_vpn: add patches for improving Batman/VXLAN performance

### DIFF
--- a/modules
+++ b/modules
@@ -1,4 +1,4 @@
-GLUON_SITE_FEEDS='hannover ffho'
+GLUON_SITE_FEEDS='hannover'
 PACKAGES_HANNOVER_REPO=https://github.com/freifunkh/ffh-packages
 PACKAGES_HANNOVER_COMMIT=a3adc64e513a4b9d1fa0201cccc55018f883fe76
 

--- a/patches/0004-vxlan-fix-performance-issues.patch
+++ b/patches/0004-vxlan-fix-performance-issues.patch
@@ -1,0 +1,100 @@
+From 486d735cb74f3c66ba08747de2b1cefc7e63b8d9 Mon Sep 17 00:00:00 2001
+From: CodeFetch <me@bibbl.com>
+Date: Tue, 22 Dec 2020 04:44:39 +0100
+Subject: [PATCH 1/1] vxlan: fix performance issues
+
+This commit includes the patches for fixing issue #2155.
+---
+ ...ance-issues-with-VXLAN-encapsulation.patch | 80 +++++++++++++++++++
+ 1 file changed, 80 insertions(+)
+ create mode 100644 patches/openwrt/9010-kernel-fix-performance-issues-with-VXLAN-encapsulation.patch
+
+diff --git a/patches/openwrt/9010-kernel-fix-performance-issues-with-VXLAN-encapsulation.patch b/patches/openwrt/9010-kernel-fix-performance-issues-with-VXLAN-encapsulation.patch
+new file mode 100644
+index 00000000..14b4cc78
+--- /dev/null
++++ b/patches/openwrt/9010-kernel-fix-performance-issues-with-VXLAN-encapsulation.patch
+@@ -0,0 +1,80 @@
++From: CodeFetch <me@bibbl.com>
++Date: Tue, 22 Dec 2020 04:35:17 +0100
++Subject: kernel: fix performance issues with VXLAN encapsulation
++
++VXLAN did not consider the needed headroom of it's lower device which thus
++lead to costly expansions of the headroom. See:
++https://patchwork.ozlabs.org/project/netdev/list/?series=216897
++
++This commit includes the needed patches.
++
++Signed-off-by: Vincent Wiemann <vw@derowe.com>
++
++diff --git a/target/linux/generic/pending-4.14/690-vxlan-add_needed_headroom_for_lower_device.patch b/target/linux/generic/pending-4.14/690-vxlan-add_needed_headroom_for_lower_device.patch
++new file mode 100644
++index 0000000000000000000000000000000000000000..1a380e62289094f0819a058ab07df0e60f0070cd
++--- /dev/null
+++++ b/target/linux/generic/pending-4.14/690-vxlan-add_needed_headroom_for_lower_device.patch
++@@ -0,0 +1,35 @@
+++From: Sven Eckelmann <sven@narfation.org>
+++Subject: [PATCH 1/2] vxlan: Add needed_headroom for lower device
+++Date: Thu, 26 Nov 2020 13:52:46 +0100
+++
+++It was observed that sending data via batadv over vxlan (on top of
+++wireguard) reduced the performance massively compared to raw ethernet or
+++batadv on raw ethernet. A check of perf data showed that the
+++vxlan_build_skb was calling all the time pskb_expand_head to allocate
+++enough headroom for:
+++
+++  min_headroom = LL_RESERVED_SPACE(dst->dev) + dst->header_len
+++  		+ VXLAN_HLEN + iphdr_len;
+++
+++But the vxlan_config_apply only requested needed headroom for:
+++
+++  lowerdev->hard_header_len + VXLAN6_HEADROOM or VXLAN_HEADROOM
+++
+++So it completely ignored the needed_headroom of the lower device. The first
+++caller of net_dev_xmit could therefore never make sure that enough headroom
+++was allocated for the rest of the transmit path.
+++
+++Cc: Annika Wickert <annika.wickert@exaring.de>
+++Signed-off-by: Sven Eckelmann <sven@narfation.org>
+++Tested-by: Annika Wickert <aw@awlnx.space>
+++Signed-off-by: Vincent Wiemann <vw@derowe.com>
+++--- a/drivers/net/vxlan.c
++++++ b/drivers/net/vxlan.c
+++@@ -3184,6 +3184,7 @@ static void vxlan_config_apply(struct ne
+++ 		dev->gso_max_segs = lowerdev->gso_max_segs;
+++ 
+++ 		needed_headroom = lowerdev->hard_header_len;
++++		needed_headroom += lowerdev->needed_headroom;
+++ 
+++ 		max_mtu = lowerdev->mtu - (use_ipv6 ? VXLAN6_HEADROOM :
+++ 					   VXLAN_HEADROOM);
++diff --git a/target/linux/generic/pending-4.14/691-vxlan-copy_needed_tailroom_from_lowerdev.patch b/target/linux/generic/pending-4.14/691-vxlan-copy_needed_tailroom_from_lowerdev.patch
++new file mode 100644
++index 0000000000000000000000000000000000000000..a02aa2e1d84993b3fc994823978d8aee8dcc482e
++--- /dev/null
+++++ b/target/linux/generic/pending-4.14/691-vxlan-copy_needed_tailroom_from_lowerdev.patch
++@@ -0,0 +1,21 @@
+++From: Sven Eckelmann <sven@narfation.org>
+++Subject: [PATCH 2/2] vxlan: Copy needed_tailroom from lowerdev
+++Date: Thu, 26 Nov 2020 13:52:47 +0100
+++
+++While vxlan doesn't need any extra tailroom, the lowerdev might need it. In
+++that case, copy it over to reduce the chance for additional (re)allocations
+++in the transmit path.
+++
+++Signed-off-by: Sven Eckelmann <sven@narfation.org>
+++Signed-off-by: Vincent Wiemann <vw@derowe.com>
+++--- a/drivers/net/vxlan.c
++++++ b/drivers/net/vxlan.c
+++@@ -3186,6 +3186,8 @@ static void vxlan_config_apply(struct ne
+++ 		needed_headroom = lowerdev->hard_header_len;
+++ 		needed_headroom += lowerdev->needed_headroom;
+++ 
++++		dev->needed_tailroom = lowerdev->needed_tailroom;
++++
+++ 		max_mtu = lowerdev->mtu - (use_ipv6 ? VXLAN6_HEADROOM :
+++ 					   VXLAN_HEADROOM);
+++ 		if (max_mtu < ETH_MIN_MTU)
+-- 
+2.29.2
+

--- a/patches/0005-batman-adv-improve-fragmentation-performance.patch
+++ b/patches/0005-batman-adv-improve-fragmentation-performance.patch
@@ -1,0 +1,142 @@
+From c405a4f5955bb6550e4382912551344560d3c9eb Mon Sep 17 00:00:00 2001
+From: CodeFetch <me@bibbl.com>
+Date: Tue, 22 Dec 2020 05:24:06 +0100
+Subject: [PATCH 1/1] batman-adv: improve fragmentation performance
+
+This commit fixes the fragmentation issues mentioned in issue #2155.
+---
+ ...dv-improve-fragmentation-performance.patch | 122 ++++++++++++++++++
+ 1 file changed, 122 insertions(+)
+ create mode 100644 patches/packages/routing/0004-batman-adv-improve-fragmentation-performance.patch
+
+diff --git a/patches/packages/routing/0004-batman-adv-improve-fragmentation-performance.patch b/patches/packages/routing/0004-batman-adv-improve-fragmentation-performance.patch
+new file mode 100644
+index 00000000..cdf51da3
+--- /dev/null
++++ b/patches/packages/routing/0004-batman-adv-improve-fragmentation-performance.patch
+@@ -0,0 +1,122 @@
++From: CodeFetch <me@bibbl.com>
++Date: Tue, 22 Dec 2020 05:07:17 +0100
++Subject: batman-adv: improve fragmentation performance
++
++See freifunk-gluon issue #2155 for details.
++
++Signed-off-by: Vincent Wiemann <vw@derowe.com>
++
++diff --git a/batman-adv/patches/1100-batman-adv-consider-fragmentation-for-needed_headroom.patch b/batman-adv/patches/1100-batman-adv-consider-fragmentation-for-needed_headroom.patch
++new file mode 100644
++index 0000000000000000000000000000000000000000..95fc85a3ea27cd5c16657e986bfaffddb9c326c4
++--- /dev/null
+++++ b/batman-adv/patches/1100-batman-adv-consider-fragmentation-for-needed_headroom.patch
++@@ -0,0 +1,12 @@
+++--- a/net/batman-adv/hard-interface.c
++++++ b/net/batman-adv/hard-interface.c
+++@@ -553,6 +553,9 @@ static void batadv_hardif_recalc_extra_s
+++ 	needed_headroom = lower_headroom + (lower_header_len - ETH_HLEN);
+++ 	needed_headroom += batadv_max_header_len();
+++ 
++++	/* fragmentation headers don't strip the unicast/... header */
++++	needed_headroom += sizeof(struct batadv_frag_packet);
++++
+++ 	soft_iface->needed_headroom = needed_headroom;
+++ 	soft_iface->needed_tailroom = lower_tailroom;
+++ }
++diff --git a/batman-adv/patches/1101-batman-adv-reserve-needed-room-for-fragments.patch b/batman-adv/patches/1101-batman-adv-reserve-needed-room-for-fragments.patch
++new file mode 100644
++index 0000000000000000000000000000000000000000..59e02149b49210dae0700d943a0310b3dce054f8
++--- /dev/null
+++++ b/batman-adv/patches/1101-batman-adv-reserve-needed-room-for-fragments.patch
++@@ -0,0 +1,62 @@
+++--- a/net/batman-adv/fragmentation.c
++++++ b/net/batman-adv/fragmentation.c
+++@@ -391,6 +391,7 @@ out:
+++ 
+++ /**
+++  * batadv_frag_create() - create a fragment from skb
++++ * @net_dev: outgoing device for fragment
+++  * @skb: skb to create fragment from
+++  * @frag_head: header to use in new fragment
+++  * @fragment_size: size of new fragment
+++@@ -401,22 +402,25 @@ out:
+++  *
+++  * Return: the new fragment, NULL on error.
+++  */
+++-static struct sk_buff *batadv_frag_create(struct sk_buff *skb,
++++static struct sk_buff *batadv_frag_create(struct net_device *net_dev,
++++					  struct sk_buff *skb,
+++ 					  struct batadv_frag_packet *frag_head,
+++ 					  unsigned int fragment_size)
+++ {
++++	unsigned int ll_reserved = LL_RESERVED_SPACE(net_dev);
++++	unsigned int tailroom = net_dev->needed_tailroom;
+++ 	struct sk_buff *skb_fragment;
+++ 	unsigned int header_size = sizeof(*frag_head);
+++ 	unsigned int mtu = fragment_size + header_size;
+++ 
+++-	skb_fragment = netdev_alloc_skb(NULL, mtu + ETH_HLEN);
++++	skb_fragment = dev_alloc_skb(ll_reserved + mtu + tailroom);
+++ 	if (!skb_fragment)
+++ 		goto err;
+++ 
+++ 	skb_fragment->priority = skb->priority;
+++ 
+++ 	/* Eat the last mtu-bytes of the skb */
+++-	skb_reserve(skb_fragment, header_size + ETH_HLEN);
++++	skb_reserve(skb_fragment, ll_reserved + header_size);
+++ 	skb_split(skb, skb_fragment, skb->len - fragment_size);
+++ 
+++ 	/* Add the header */
+++@@ -439,11 +443,12 @@ int batadv_frag_send_packet(struct sk_bu
+++ 			    struct batadv_orig_node *orig_node,
+++ 			    struct batadv_neigh_node *neigh_node)
+++ {
++++	struct net_device *net_dev = neigh_node->if_incoming->net_dev;
+++ 	struct batadv_priv *bat_priv;
+++ 	struct batadv_hard_iface *primary_if = NULL;
+++ 	struct batadv_frag_packet frag_header;
+++ 	struct sk_buff *skb_fragment;
+++-	unsigned int mtu = neigh_node->if_incoming->net_dev->mtu;
++++	unsigned int mtu = net_dev->mtu;
+++ 	unsigned int header_size = sizeof(frag_header);
+++ 	unsigned int max_fragment_size, num_fragments;
+++ 	int ret;
+++@@ -503,7 +508,7 @@ int batadv_frag_send_packet(struct sk_bu
+++ 			goto put_primary_if;
+++ 		}
+++ 
+++-		skb_fragment = batadv_frag_create(skb, &frag_header,
++++		skb_fragment = batadv_frag_create(net_dev, skb, &frag_header,
+++ 						  max_fragment_size);
+++ 		if (!skb_fragment) {
+++ 			ret = -ENOMEM;
++diff --git a/batman-adv/patches/1102-batman-adv-dont-always-reallocate-the-fragmentation-skb-head.patch b/batman-adv/patches/1102-batman-adv-dont-always-reallocate-the-fragmentation-skb-head.patch
++new file mode 100644
++index 0000000000000000000000000000000000000000..13f8da0ba1855e0dbeecb9d6680fed41cff5a5e0
++--- /dev/null
+++++ b/batman-adv/patches/1102-batman-adv-dont-always-reallocate-the-fragmentation-skb-head.patch
++@@ -0,0 +1,22 @@
+++--- a/net/batman-adv/fragmentation.c
++++++ b/net/batman-adv/fragmentation.c
+++@@ -527,13 +527,15 @@ int batadv_frag_send_packet(struct sk_bu
+++ 		frag_header.no++;
+++ 	}
+++ 
+++-	/* Make room for the fragment header. */
+++-	if (batadv_skb_head_push(skb, header_size) < 0 ||
+++-	    pskb_expand_head(skb, header_size + ETH_HLEN, 0, GFP_ATOMIC) < 0) {
+++-		ret = -ENOMEM;
++++	/* make sure that there is at least enough head for the fragmentation
++++	 * and ethernet headers
++++	 */
++++	ret = skb_cow_head(skb, ETH_HLEN + header_size);
++++	if (ret < 0)
+++ 		goto put_primary_if;
+++ 	}
+++ 
++++	skb_push(skb, header_size);
+++ 	memcpy(skb->data, &frag_header, header_size);
+++ 
+++ 	/* Send the last fragment */
+-- 
+2.29.2
+

--- a/site.mk
+++ b/site.mk
@@ -30,9 +30,7 @@ GLUON_FEATURES := \
 ##	When removing ffho-web-autoupdater, remember to readd gluon-web-autoupdater again
 
 GLUON_SITE_PACKAGES := \
-	-gluon-web-autoupdater \
-	ffho-autoupdater-wifi-fallback \
-	ffho-web-autoupdater \
+	gluon-web-autoupdater \
 	haveged \
 	iwinfo \
 	gluon-segment-mover \


### PR DESCRIPTION
This commit adds the performance-improving kernel patches mentioned in:
https://github.com/freifunk-gluon/gluon/issues/2155
