### PR TITLE
site.conf: place pubkey_privacy correctly

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -35,7 +35,6 @@
 		fastd = {
 			configurable = true,
 			methods = {'salsa2012+umac'},
-			pubkey_privacy = false,
 			groups = {
 				backbone = {
 					limit = 1,
@@ -50,6 +49,7 @@
 			ingress = 4000,
 			egress = 500,
 		},
+		pubkey_privacy = false,
 	},
 
 	autoupdater = {


### PR DESCRIPTION
In case we conclude this is not a risk for our network (with neither fastd nor wireguard), we should fix this.

resolves #54 