### PR TITLE
Added Umland and Region Prefix to Domain Names

### DIFF
--- a/domains/dom0.conf
+++ b/domains/dom0.conf
@@ -94,7 +94,6 @@
 		},
 	} } } } },
 
-	-- primary domain name "Domain 0" should be hidden in config mode
-	hide_domain = { 'dom0' },
+	hide_domain = true,
 
 }

--- a/domains/dom10.conf
+++ b/domains/dom10.conf
@@ -6,6 +6,7 @@
 	domain_names = {
 		hameln = 'Hameln',
 		alfeld = 'Alfeld',
+		unconfigured = 'Bitte auswählen',
 		dom10 = 'Domain 10',
 	},	
 

--- a/domains/gen.py
+++ b/domains/gen.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# coding: utf8
 
 import argparse
 import os
@@ -10,8 +11,8 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 h = "Hannover: "
 domains = {
-    0: { "names": { "legacy": "Legacy" } },
-    10: { "names": { "hameln": "Hameln", "alfeld": "Alfeld" }, },
+    0: { "names": { "legacy": "Legacy" }, "hide": True },
+    10: { "names": { "hameln": "Hameln", "alfeld": "Alfeld", "unconfigured": "Bitte auswählen" }, },
     11: { "names": { "lenthe": "Lenthe" } },
     12: { "names": { "steinhude": "Steinhude" } },
     13: { "names": { "springe": "Springe", "obernkirchen": "Obernkirchen" } },

--- a/site.conf
+++ b/site.conf
@@ -3,7 +3,7 @@
 	site_name = 'Freifunk Hannover',
 	site_code = 'ffh',
 
-	default_domain = 'legacy',
+	default_domain = 'unconfigured',
 
 	opkg = {
 		openwrt = 'http://downloads.openwrt.org/releases/packages-%v/%A',


### PR DESCRIPTION
Wie vor einiger Zeit (Monate? Habs etwas aus dem Auge verloren) besprochen hier ein Pull Request um die Benennung der Domains in der Firmware etwas anzupassen. Eingeteilt nun wie auch die "Hannover" Stadtteile mit Umland und Region Präfix.

Sollten keine beanstandungen sein würde ich mich mit der Änderung endlich mal an eine vH22 machen.