### PR TITLE
Newmaster

### DIFF
--- a/patches/0003-openwrt-added-TL-WR841ND-N-8M-and-16M-Variants-to-ath79.patch
+++ b/patches/0003-openwrt-added-TL-WR841ND-N-8M-and-16M-Variants-to-ath79.patch
@@ -1,10 +1,11 @@
-From f5680dcf5b0db292ff3f73ea8cde0ccf183ba62d Mon Sep 17 00:00:00 2001
+From 972316226ea6a21e1fa94ca721b9e57288aa35de Mon Sep 17 00:00:00 2001
 From: Dark4MD <github.web@manu.li>
 Date: Mon, 10 May 2021 19:36:12 +0200
 Subject: [PATCH] openwrt: added TL-WR841ND/N 8M and 16M Variants to ath79
 
 rebased on master by aiyion due to:
 commit af74622cb5 ("ath79-generic: sort TP-Link devices")
+commit 1ad629e503 ("ath79-generic: sort TP-Link devices")
 ---
  ...841ND-N-8M-and-16M-Variants-to-ath79.patch | 753 ++++++++++++++++++
  targets/ath79-generic                         |  40 +
@@ -771,14 +772,13 @@ index 00000000..2f66b0b1
 +2.29.2.windows.2
 +
 diff --git a/targets/ath79-generic b/targets/ath79-generic
-index 4cd54378..aff47ee3 100644
+index 979a7f3c..33f63a47 100644
 --- a/targets/ath79-generic
 +++ b/targets/ath79-generic
-@@ -110,3 +110,43 @@ device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
- 
+@@ -112,4 +112,44 @@ device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
  device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
  device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
-+
+ 
 +device('tp-link-tl-wr841n-nd-mod-ath79-8m-v8', 'tplink_tl-wr841-v8-8m', {
 +	factory = false,
 +	manifest_aliases = {'tp-link-tl-wr841n-nd-mod-8m-v8'},
@@ -818,6 +818,8 @@ index 4cd54378..aff47ee3 100644
 +	factory = false,
 +	manifest_aliases = {'tp-link-tl-wr841n-nd-mod-16m-v8'},
 +})
++
+ device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 -- 
-2.32.0
+2.33.0
 

--- a/patches/0003-openwrt-added-TL-WR841ND-N-8M-and-16M-Variants-to-ath79.patch
+++ b/patches/0003-openwrt-added-TL-WR841ND-N-8M-and-16M-Variants-to-ath79.patch
@@ -1,8 +1,10 @@
-From 013e2e9e84728ca032fb59b793b57f18ccbfd01e Mon Sep 17 00:00:00 2001
+From f5680dcf5b0db292ff3f73ea8cde0ccf183ba62d Mon Sep 17 00:00:00 2001
 From: Dark4MD <github.web@manu.li>
 Date: Mon, 10 May 2021 19:36:12 +0200
 Subject: [PATCH] openwrt: added TL-WR841ND/N 8M and 16M Variants to ath79
 
+rebased on master by aiyion due to:
+commit af74622cb5 ("ath79-generic: sort TP-Link devices")
 ---
  ...841ND-N-8M-and-16M-Variants-to-ath79.patch | 753 ++++++++++++++++++
  targets/ath79-generic                         |  40 +
@@ -769,13 +771,13 @@ index 00000000..2f66b0b1
 +2.29.2.windows.2
 +
 diff --git a/targets/ath79-generic b/targets/ath79-generic
-index f2c1a952..4ee05ad8 100644
+index 4cd54378..aff47ee3 100644
 --- a/targets/ath79-generic
 +++ b/targets/ath79-generic
-@@ -92,3 +92,43 @@ device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
- 	factory = false,
- 	broken = true, -- 64M ath9k + ath10k & power LED not working
- })
+@@ -110,3 +110,43 @@ device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
+ 
+ device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
+ device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 +
 +device('tp-link-tl-wr841n-nd-mod-ath79-8m-v8', 'tplink_tl-wr841-v8-8m', {
 +	factory = false,
@@ -817,5 +819,5 @@ index f2c1a952..4ee05ad8 100644
 +	manifest_aliases = {'tp-link-tl-wr841n-nd-mod-16m-v8'},
 +})
 -- 
-2.29.2.windows.2
+2.32.0
 

--- a/site.mk
+++ b/site.mk
@@ -175,4 +175,5 @@ GLUON_LANGS ?= de en fr
 GLUON_DEPRECATED ?= upgrade
 
 # Set default branch for building custom images
-GLUON_BRANCH ?= experimental
+GLUON_AUTOUPDATER_BRANCH ?= experimental
+GLUON_AUTOUPDATER_ENABLED ?= 1


### PR DESCRIPTION
These are the commits that were part of nightly but are not in master yet.


The other way around is on the branch https://github.com/freifunkh/site/tree/nightlydrop
If we would apply both branch updates, they'd be identical.

Therefore we can then cleanly drop nightly and know the only commits we're missing are patches that were in nightly at some point but aren't anymore.

This PR is up for review; let me know if this contains commits that should not be part of our new master branch.