### PR TITLE
site.conf: add srd (aditional outdoor) channels

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -24,7 +24,7 @@
 	},
 	wifi5 = {
 		channel = 44,
-		outdoor_chanlist = '100-140',
+		outdoor_chanlist = '100-173',
 		mesh = {
 			mcast_rate = 12000,
 		},


### PR DESCRIPTION
> 149-161 and 165-173
> 
> in germany these channels are capped to 25mW.
> They are expected to have significantly more airtime available.

@ctandi suggested to add these channels to our site, so he might test that this PR does indeed work for him as expected.