### PR TITLE
workflows: check for git status in patches action

### DIFF
--- a/.github/workflows/gluon-check-patches.yml
+++ b/.github/workflows/gluon-check-patches.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'patches/**'
       - '.github/workflows/gluon-check-patches.yml'
+  schedule:
+    - cron: '16 * * * *'
 permissions:
   contents: read
 

--- a/.github/workflows/gluon-check-patches.yml
+++ b/.github/workflows/gluon-check-patches.yml
@@ -1,0 +1,44 @@
+---
+name: Gluon check patches
+on:
+  push:
+    paths:
+      - 'patches/**'
+      - '.github/workflows/gluon-check-patches.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'patches/**'
+      - '.github/workflows/gluon-check-patches.yml'
+permissions:
+  contents: read
+
+jobs:
+  gluon-check-patches:
+    name: Gluon check patches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone gluon repo
+        uses: actions/checkout@v3
+        with:
+          repository: freifunk-gluon/gluon
+
+      - name: Clone site repo
+        uses: actions/checkout@v3
+        with:
+          path: gluon/site
+
+      - name: apply site patches
+        working-directory: ./gluon
+        run: git -c user.name='freifunkh Patch Manager' -c user.email='freifunkh@void.example.com' -c commit.gpgsign=false am --whitespace=nowarn --committer-date-is-author-date site/patches/*
+
+
+# The following should match the last steps in gluons check-patches.yml
+      - name: Refresh patches
+        run: make refresh-patches GLUON_SITEDIR="contrib/ci/minimal-site"
+
+      - name: Show diff
+        run: git status; git diff
+
+      - name: Patch status
+        run: git diff-files --quiet

--- a/.github/workflows/site-check-patches.yml
+++ b/.github/workflows/site-check-patches.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'patches/**'
       - '.github/workflows/site-check-patches.yml'
+  schedule:
+    - cron: '16 * * * *'
 permissions:
   contents: read
 

--- a/.github/workflows/site-check-patches.yml
+++ b/.github/workflows/site-check-patches.yml
@@ -1,0 +1,34 @@
+---
+name: Site check patches
+on:
+  push:
+    paths:
+      - 'patches/**'
+      - '.github/workflows/site-check-patches.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'patches/**'
+      - '.github/workflows/site-check-patches.yml'
+permissions:
+  contents: read
+
+jobs:
+  site-check-patches:
+    name: site check patches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone site repo
+        uses: actions/checkout@v3
+
+      - name: Run refresh_ffh_patches.sh
+        working-directory: ./
+        run: ./refresh_ffh_patches.sh
+
+# The following should match the last steps from gluons check-patches.yml
+
+      - name: Show diff
+        run: git status; git diff
+
+      - name: Patch status
+        run: git diff-files --quiet

--- a/.github/workflows/site-check-patches.yml
+++ b/.github/workflows/site-check-patches.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Show diff
         run: git status; git diff
 
-      - name: Patch status
+      - name: Patch diff
         run: git diff-files --quiet
+
+      - name: Patch status
+        run: test -z "$(git status --porcelain)"

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,61 @@
+# Patches
+
+As gluon, this repo is upstream-first.
+Which means, if a patch can be upstreamed to gluon, it should be.
+
+
+## Patches in Gluons repo
+
+Whenever Gluon implements changes that cannot be upstreamed to OpenWrt or related repos (yet),
+Patchfiles are created and tracked in a subdir of the `patches`-folder in the gluon repo.
+
+Patches in that repo have to be structured in a specific way.
+There's a helper in the gluon repo, which reformats them accordingly,
+available by calling `make refresh-patches`.
+
+After calling it, the file is in the desired format, but uncommitted.
+Commit them (if necessary using `--amend`, if the commit that created italready exists).
+
+## Patches in this repo
+
+Our patches are similar:
+
+Whenever we implement changes that cannot be upstreamed to Gluon (yet),
+Patchfiles are created and tracked in the `patches`-folder in this repo.
+
+We structure these patches the very same way gluon does.
+There's again a helper in this repo, which formats them as intended.
+available by calling `refresh_ffh_patches.sh`.
+
+Calling it does change the files in the patch folder if necessary, but does not commit them.
+That's your task again.
+
+
+## Careful
+
+Working with these helpers is a fast and powerful workflow;
+which means you can break things fast.
+
+Make sure you have **no uncommited changes** in the respective repo, before calling either of them.
+That way recovering and assessing the situation is easy using git.
+
+
+## A clean patch
+
+If the folder contains only clean patches, calling either helper does not change anything.
+So calling them before pushing is a good way to make sure the GitHub actions will run through.
+
+
+# Use-cases
+
+## Updating a patch
+
+If we want to change an exiting patch of ours, we apply the *existing* patches to the proper gluon-branch can then alter the commits appropriately.
+After commiting the gluon changes using `--amend` we can then create a patch of it using `git format-patch`, and replace the old patch version with it.
+Now comes the new part: call `refresh_ffh_patches.sh` to have the script reformat it appropriately.
+This will minimize the differences to previous versions of the patches, regardless which OS we use to create them.
+
+## Gluon added a patch itself
+
+The action will fail, if tat breaks the order of existing patches.
+renaming the numbers manually and then fixing the script again will do the trick.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 |:----------------:|:----------------------:|:------------------------------------------------------------------------:|:-----------------------------:|
 |      master      |                        |                                  master                                  | nightly builds, manual builds |
 |      stable      |  mostly latest release | [See here](https://hannover.freifunk.net/wiki/Freifunk/FirmwareReleases) |    manual builds, releases    |
-| master-wireguard |    currently unused    |                                  master                                  | nightly builds, manual builds |
+| master-wireguard |                        |                                  master                                  | nightly builds, manual builds |
 | stable-wireguard |  mostly latest release | [See here](https://hannover.freifunk.net/wiki/Freifunk/FirmwareReleases) |    manual builds, releases    |
 |       next       | currently not used yet |                                   next                                   |         manual builds         |
 

--- a/modules
+++ b/modules
@@ -1,6 +1,6 @@
 GLUON_SITE_FEEDS='hannover'
 PACKAGES_HANNOVER_REPO=https://github.com/freifunkh/ffh-packages
-PACKAGES_HANNOVER_COMMIT=04813d8c5b46077b27b6b99a92992ef994fb4e79
+PACKAGES_HANNOVER_COMMIT=cfd9c3762033e2b57ca45b537d7b14deb3dc7f58
 
 PACKAGES_FFHO_REPO=https://git.ffho.net/FreifunkHochstift/ffho-packages.git
 PACKAGES_FFHO_BRANCH=master

--- a/modules
+++ b/modules
@@ -1,6 +1,6 @@
 GLUON_SITE_FEEDS='hannover'
 PACKAGES_HANNOVER_REPO=https://github.com/freifunkh/ffh-packages
-PACKAGES_HANNOVER_COMMIT=34e16806732562ecb93ad20fb33d314fe446166c
+PACKAGES_HANNOVER_COMMIT=55f5cc4a1d9d2bd1c0c9f8071d0ccbb9e8b90539
 
 PACKAGES_FFHO_REPO=https://git.ffho.net/FreifunkHochstift/ffho-packages.git
 PACKAGES_FFHO_BRANCH=master

--- a/modules
+++ b/modules
@@ -1,6 +1,6 @@
 GLUON_SITE_FEEDS='hannover'
 PACKAGES_HANNOVER_REPO=https://github.com/freifunkh/ffh-packages
-PACKAGES_HANNOVER_COMMIT=cfd9c3762033e2b57ca45b537d7b14deb3dc7f58
+PACKAGES_HANNOVER_COMMIT=34e16806732562ecb93ad20fb33d314fe446166c
 
 PACKAGES_FFHO_REPO=https://git.ffho.net/FreifunkHochstift/ffho-packages.git
 PACKAGES_FFHO_BRANCH=master

--- a/patches/0001-batman-adv-fix-when-vlan-crc-0x00000000.patch
+++ b/patches/0001-batman-adv-fix-when-vlan-crc-0x00000000.patch
@@ -1,16 +1,10 @@
-From 57756bf8ff39784639fd5299a118af17cbdf5d36 Mon Sep 17 00:00:00 2001
 From: lemoer <git@irrelefant.net>
 Date: Mon, 23 Apr 2018 02:55:52 +0200
-Subject: [PATCH] batman-adv: fix when vlan crc == 0x00000000
-
----
- .../routing/0005-batman-adv-add-patch.patch        | 41 ++++++++++++++++++++++
- 1 file changed, 41 insertions(+)
- create mode 100644 patches/packages/routing/0005-batman-adv-add-patch.patch
+Subject: batman-adv: fix when vlan crc == 0x00000000
 
 diff --git a/patches/packages/routing/0005-batman-adv-add-patch.patch b/patches/packages/routing/0005-batman-adv-add-patch.patch
 new file mode 100644
-index 00000000..7d92a1c2
+index 0000000000000000000000000000000000000000..7d92a1c2ca4a3fb0daed6b42482c1860b7de1733
 --- /dev/null
 +++ b/patches/packages/routing/0005-batman-adv-add-patch.patch
 @@ -0,0 +1,41 @@
@@ -55,6 +49,3 @@ index 00000000..7d92a1c2
 ++-- 
 ++2.11.0
 ++
--- 
-2.16.2
-

--- a/patches/0002-patches-uradvd-change-ip-lifetimes-to-150-300-seconds.patch
+++ b/patches/0002-patches-uradvd-change-ip-lifetimes-to-150-300-seconds.patch
@@ -1,16 +1,10 @@
-From 86d188616d7a03e6e7ce8312a3968d7c54687acb Mon Sep 17 00:00:00 2001
 From: lemoer <git@irrelefant.net>
 Date: Thu, 31 May 2018 23:52:48 +0200
-Subject: [PATCH] patches: uradvd: change ip lifetimes to 150/300 seconds
-
----
- ...vd-change-ip-lifetimes-to-150-300-seconds.patch | 27 ++++++++++++++++++++++
- 1 file changed, 27 insertions(+)
- create mode 100644 patches/packages/gluon/0001-uradvd-change-ip-lifetimes-to-150-300-seconds.patch
+Subject: patches: uradvd: change ip lifetimes to 150/300 seconds
 
 diff --git a/patches/packages/gluon/0001-uradvd-change-ip-lifetimes-to-150-300-seconds.patch b/patches/packages/gluon/0001-uradvd-change-ip-lifetimes-to-150-300-seconds.patch
 new file mode 100644
-index 00000000..b6bf1cdb
+index 0000000000000000000000000000000000000000..b6bf1cdb1b89ba4fb3c13108aa6c56342bc42100
 --- /dev/null
 +++ b/patches/packages/gluon/0001-uradvd-change-ip-lifetimes-to-150-300-seconds.patch
 @@ -0,0 +1,27 @@
@@ -41,6 +35,3 @@ index 00000000..b6bf1cdb
 + 
 + /* And these in milliseconds */
 + #define MAX_RA_DELAY_TIME 500u
--- 
-2.11.0
-

--- a/patches/0003-patches-openwrt-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
+++ b/patches/0003-patches-openwrt-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
@@ -1,59 +1,20 @@
-From 0db9016d1646448272d4fafe43b720d10416ddbd Mon Sep 17 00:00:00 2001
 From: Dark4MD <github.web@manu.li>
 Date: Thu, 5 May 2022 18:04:46 +0200
-Subject: [PATCH] patches/openwrt: add TL-WR841ND/N 8M and 16M variants to
- ath79
+Subject: patches/openwrt: add TL-WR841ND/N 8M and 16M variants to ath79
 
----
- ...841ND-N-8M-and-16M-variants-to-ath79.patch | 753 ++++++++++++++++++
- targets/ath79-generic                         |  40 +
- 2 files changed, 793 insertions(+)
- create mode 100644 patches/openwrt/0009-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
-
-diff --git a/patches/openwrt/0009-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch b/patches/openwrt/0009-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
+diff --git a/patches/openwrt/0013-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch b/patches/openwrt/0013-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
 new file mode 100644
-index 00000000..d803a772
+index 0000000000000000000000000000000000000000..83179400f258f2152ac2b8e88260e6879036df22
 --- /dev/null
-+++ b/patches/openwrt/0009-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
-@@ -0,0 +1,753 @@
-+From f1be647c25c3b1c393add1cdba6b2ad2d23e0b71 Mon Sep 17 00:00:00 2001
++++ b/patches/openwrt/0013-add-TL-WR841ND-N-8M-and-16M-variants-to-ath79.patch
+@@ -0,0 +1,719 @@
 +From: Dark4MD <github.web@manu.li>
 +Date: Thu, 5 May 2022 17:45:14 +0200
-+Subject: [PATCH] add TL-WR841ND/N 8M and 16M variants to ath79
-+
-+---
-+ .../dts/ar9341_tplink_tl-wr841-v8-16m.dts     |  61 +++++++++
-+ .../dts/ar9341_tplink_tl-wr841-v8-8m.dts      |  61 +++++++++
-+ .../dts/qca9533_tplink_tl-wr841-16m.dtsi      | 124 ++++++++++++++++++
-+ .../ath79/dts/qca9533_tplink_tl-wr841-8m.dtsi | 124 ++++++++++++++++++
-+ .../dts/qca9533_tplink_tl-wr841-v10-16m.dts   |  15 +++
-+ .../dts/qca9533_tplink_tl-wr841-v10-8m.dts    |  15 +++
-+ .../dts/qca9533_tplink_tl-wr841-v11-16m.dts   |   8 ++
-+ .../dts/qca9533_tplink_tl-wr841-v11-16m.dtsi  |  24 ++++
-+ .../dts/qca9533_tplink_tl-wr841-v11-8m.dts    |   8 ++
-+ .../dts/qca9533_tplink_tl-wr841-v11-8m.dtsi   |  24 ++++
-+ .../dts/qca9533_tplink_tl-wr841-v9-16m.dts    |  15 +++
-+ .../dts/qca9533_tplink_tl-wr841-v9-8m.dts     |  15 +++
-+ .../generic/base-files/etc/board.d/01_leds    |   8 ++
-+ .../generic/base-files/etc/board.d/02_network |   8 ++
-+ target/linux/ath79/image/generic-tp-link.mk   |  86 ++++++++++++
-+ 15 files changed, 596 insertions(+)
-+ create mode 100644 target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-16m.dts
-+ create mode 100644 target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-8m.dts
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-16m.dtsi
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-8m.dtsi
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-16m.dts
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-8m.dts
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dts
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dtsi
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dts
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dtsi
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-16m.dts
-+ create mode 100644 target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-8m.dts
++Subject: add TL-WR841ND/N 8M and 16M variants to ath79
 +
 +diff --git a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-16m.dts b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-16m.dts
 +new file mode 100644
-+index 0000000000..457d55122e
++index 0000000000000000000000000000000000000000..457d55122e545857fa31f6b3ba77ca8b1009116d
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-16m.dts
 +@@ -0,0 +1,61 @@
@@ -120,7 +81,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-8m.dts b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-8m.dts
 +new file mode 100644
-+index 0000000000..dc9f48f27b
++index 0000000000000000000000000000000000000000..dc9f48f27b92bdb2f4d4328a14efbd1603c25e92
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8-8m.dts
 +@@ -0,0 +1,61 @@
@@ -187,7 +148,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-16m.dtsi b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-16m.dtsi
 +new file mode 100644
-+index 0000000000..2c6ab9d3c2
++index 0000000000000000000000000000000000000000..2c6ab9d3c277e90fae4798fe9fd91e2d2accb52d
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-16m.dtsi
 +@@ -0,0 +1,124 @@
@@ -317,7 +278,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-8m.dtsi b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-8m.dtsi
 +new file mode 100644
-+index 0000000000..81317a37b8
++index 0000000000000000000000000000000000000000..81317a37b8ee5251765d6eb3033749150187cc09
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-8m.dtsi
 +@@ -0,0 +1,124 @@
@@ -447,7 +408,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-16m.dts b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-16m.dts
 +new file mode 100644
-+index 0000000000..5cffe57a03
++index 0000000000000000000000000000000000000000..5cffe57a03fc08fba8c3b2ca198a4c2fdbbab9de
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-16m.dts
 +@@ -0,0 +1,15 @@
@@ -468,7 +429,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-8m.dts b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-8m.dts
 +new file mode 100644
-+index 0000000000..7bf8871fce
++index 0000000000000000000000000000000000000000..7bf8871fce5a76f4f6a805c1a4ea50223770af2e
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v10-8m.dts
 +@@ -0,0 +1,15 @@
@@ -489,7 +450,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dts b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dts
 +new file mode 100644
-+index 0000000000..220953f1be
++index 0000000000000000000000000000000000000000..220953f1be18e286cf2b3b1c3cbe4348ed9b66fa
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dts
 +@@ -0,0 +1,8 @@
@@ -503,7 +464,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dtsi b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dtsi
 +new file mode 100644
-+index 0000000000..e40621ceeb
++index 0000000000000000000000000000000000000000..e40621ceeb7c5ba40103a26e359fb6f5bd33c691
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-16m.dtsi
 +@@ -0,0 +1,24 @@
@@ -533,7 +494,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dts b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dts
 +new file mode 100644
-+index 0000000000..f24e069b40
++index 0000000000000000000000000000000000000000..f24e069b401d65f143ea46cfaa72c84ccac40dc5
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dts
 +@@ -0,0 +1,8 @@
@@ -547,7 +508,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dtsi b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dtsi
 +new file mode 100644
-+index 0000000000..92eab6e8da
++index 0000000000000000000000000000000000000000..92eab6e8da711804556baf6562538c00482628e0
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11-8m.dtsi
 +@@ -0,0 +1,24 @@
@@ -577,7 +538,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-16m.dts b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-16m.dts
 +new file mode 100644
-+index 0000000000..83af5a2559
++index 0000000000000000000000000000000000000000..83af5a2559bc6731032e8775d725c7cd226b1856
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-16m.dts
 +@@ -0,0 +1,15 @@
@@ -598,7 +559,7 @@ index 00000000..d803a772
 ++};
 +diff --git a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-8m.dts b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-8m.dts
 +new file mode 100644
-+index 0000000000..000775bbbc
++index 0000000000000000000000000000000000000000..000775bbbcfa33d0da4e743f320d04a1cdd163ec
 +--- /dev/null
 ++++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9-8m.dts
 +@@ -0,0 +1,15 @@
@@ -618,10 +579,10 @@ index 00000000..d803a772
 ++	};
 ++};
 +diff --git a/target/linux/ath79/generic/base-files/etc/board.d/01_leds b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
-+index 8b4c83fd2c..b22c1d2cc0 100644
++index 0809e40137ed832b4defc18bc1ac39ab9c9cbb0b..f8bdf5e8f64e09ba92fb037d4da6b0d72e8d043b 100644
 +--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
 ++++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
-+@@ -344,6 +344,12 @@ tplink,archer-c6-v2-us)
++@@ -347,6 +347,12 @@ tplink,archer-c6-v2-us)
 + 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x02"
 + 	;;
 + tplink,archer-c25-v1|\
@@ -634,7 +595,7 @@ index 00000000..d803a772
 + tplink,tl-wr842n-v3)
 + 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 + 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x10"
-+@@ -406,6 +412,8 @@ tplink,tl-wpa8630-v1)
++@@ -409,6 +415,8 @@ tplink,tl-wpa8630-v1)
 + 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3c"
 + 	;;
 + tplink,tl-wr841hp-v2|\
@@ -644,10 +605,10 @@ index 00000000..d803a772
 + 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 + 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x04"
 +diff --git a/target/linux/ath79/generic/base-files/etc/board.d/02_network b/target/linux/ath79/generic/base-files/etc/board.d/02_network
-+index 4d3296c0af..dd9a33a51d 100644
++index 8f9516b8c681fd09c37fb183a63c17cf84f94bfc..54f7e4592f5c09a396dfb1b1ec83e908e39b8a49 100644
 +--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
 ++++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
-+@@ -169,6 +169,12 @@ ath79_setup_interfaces()
++@@ -171,6 +171,12 @@ ath79_setup_interfaces()
 + 	tplink,archer-c60-v2|\
 + 	tplink,archer-c60-v3|\
 + 	tplink,tl-wdr3500-v1|\
@@ -660,7 +621,7 @@ index 00000000..d803a772
 + 	tplink,tl-wr842n-v1|\
 + 	tplink,tl-wr842n-v3)
 + 		ucidef_set_interface_wan "eth1"
-+@@ -444,6 +450,8 @@ ath79_setup_interfaces()
++@@ -447,6 +453,8 @@ ath79_setup_interfaces()
 + 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "5:lan:4"
 + 		;;
 + 	tplink,tl-wr841hp-v2|\
@@ -670,7 +631,7 @@ index 00000000..d803a772
 + 	tplink,tl-wr941hp-v1)
 + 		ucidef_set_interface_wan "eth1"
 +diff --git a/target/linux/ath79/image/generic-tp-link.mk b/target/linux/ath79/image/generic-tp-link.mk
-+index fed572c884..3a9f2a5821 100644
++index fed572c884c75bd21081c7c22dd4652ecefdd993..3a9f2a5821d3e3729f5a0ac842b93da638baacf0 100644
 +--- a/target/linux/ath79/image/generic-tp-link.mk
 ++++ b/target/linux/ath79/image/generic-tp-link.mk
 +@@ -796,6 +796,92 @@ define Device/tplink_tl-wr841hp-v3
@@ -766,14 +727,11 @@ index 00000000..d803a772
 + define Device/tplink_tl-wr842n-v1
 +   $(Device/tplink-8m)
 +   SOC := ar7241
-+-- 
-+2.38.0
-+
 diff --git a/targets/ath79-generic b/targets/ath79-generic
-index 6830c368..f8891687 100644
+index dc8849469004b1c66974f48c35c218ed17f1027a..6e5cd23ecb3290b0765602ba439b3346192ff9c8 100644
 --- a/targets/ath79-generic
 +++ b/targets/ath79-generic
-@@ -464,6 +464,46 @@ device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
+@@ -497,6 +497,46 @@ device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
  
  device('tp-link-tl-wr810n-v1', 'tplink_tl-wr810n-v1')
  
@@ -820,6 +778,3 @@ index 6830c368..f8891687 100644
  device('tp-link-tl-wr842n-v3', 'tplink_tl-wr842n-v3', {
  	manifest_aliases = {
  		'tp-link-tl-wr842n-nd-v3', -- upgrade from OpenWrt 19.07
--- 
-2.38.0
-

--- a/refresh_ffh_patches.sh
+++ b/refresh_ffh_patches.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+shopt -s nullglob
+
+# create patchdir
+PATCHDIR=patching
+mkdir -p "$PATCHDIR"
+trap 'rm -rf "$PATCHDIR"' EXIT
+
+# clone gluon
+git clone --depth 1 --single-branch https://github.com/freifunk-gluon/gluon.git $PATCHDIR
+
+cd $PATCHDIR
+
+# apply all site patches
+for patch in "../patches"/*.patch; do
+	git -c user.name='Freifunkh Patch Manager' -c user.email='freifunkh@void.example.com' -c commit.gpgsign=false am --whitespace=nowarn --committer-date-is-author-date "$patch"
+done
+
+git checkout -B patched >/dev/null
+
+# recreate site patches from just created commits
+n=0
+for commit in $(git rev-list --reverse --no-merges origin/HEAD..patched); do
+	(( ++n ))
+	echo "Updating: $(git log --format=%s -n 1 "$commit")"
+	git -c core.abbrev=40 show --pretty=format:'From: %an <%ae>%nDate: %aD%nSubject: %B' --no-renames --binary "$commit" > "../patches/$(printf '%04u' "$n")-$(git show -s --pretty=format:%f "$commit").patch"
+done
+
+cd ..
+
+rm -rf "$PATCHDIR"
+

--- a/site.conf
+++ b/site.conf
@@ -109,6 +109,20 @@
 					'95eb11173b3b0758d675b1646fb03c0d1722d8de01788149c7c74c89ac424f23', -- Gluon-Nightly
 				},
 			},
+			nightly_wireguard = {
+				name = 'nightly_wireguard',
+				mirrors = {'http://build.ffh.zone/job/gluon-nightly-wireguard/lastSuccessfulBuild/artifact/images/sysupgrade'},
+				good_signatures = 1,
+				pubkeys = {
+					'1f5cec7fea138e801587b9ee8b1fa1de98f4dcdda3c5cfd266e663aeb18ab105', -- Aiyion
+					'80f8671f9b7a5a45eac6af662b40e2f80306d6058427e0c7325a5106ddf4a147', -- 1977er
+					'f919863edb7df4da3ca47285cdea21d912ce8ebac349e6c3f48e8804d78bb728', -- Lemoer
+					'48a93732d6f1914c96a74c907491fc95f63bde5924f5484c4fe6a1ddc7645481', -- Raute
+					'abcf54acea608aeb4d65b9ef8fdf03b49f874a67f1c16c65c8ef3465ca5c7a48', -- Tobby
+					'989de045c015b516d0dd7eca323eb421610b5b537b766ff4a0c171fab57cef7e', -- DarkAMD
+					'95eb11173b3b0758d675b1646fb03c0d1722d8de01788149c7c74c89ac424f23', -- Gluon-Nightly
+				},
+			},
 			wireguard = {
 				name = 'wireguard',
 				mirrors = {'http://firmware.ffh.zone/wireguard/sysupgrade'},

--- a/site.conf
+++ b/site.conf
@@ -8,7 +8,7 @@
 	opkg = {
 		openwrt = 'http://downloads.openwrt.org/releases/packages-%v/%A',
 		extra = {
-			modules = 'http://build.ffh.zone/job/gluon-beta/ws/beta/packages/gluon-%GS-%GR/%S',
+			modules = 'http://build.ffh.zone/job/gluon-nightly/lastSuccessfulBuild/artifact/packages/gluon-%GS-%GR/%S',
 		},
 	},
 


### PR DESCRIPTION
When refreshing the patches results in renumbering patches to a higher number the `git diff` output might be empty. The porcelain (machine-readable) out put of `git status` would not be.

