### PR TITLE
[stable-wireguard] modules: bump ffh-packages commit

### DIFF
--- a/modules
+++ b/modules
@@ -1,6 +1,6 @@
 GLUON_SITE_FEEDS='hannover community'
 PACKAGES_HANNOVER_REPO=https://github.com/freifunkh/ffh-packages
-PACKAGES_HANNOVER_COMMIT=55f5cc4a1d9d2bd1c0c9f8071d0ccbb9e8b90539
+PACKAGES_HANNOVER_COMMIT=87214821716cd766f8b3c002830ef0f24cd859ac
 
 PACKAGES_FFHO_REPO=https://git.ffho.net/FreifunkHochstift/ffho-packages.git
 PACKAGES_FFHO_BRANCH=master


### PR DESCRIPTION
See https://github.com/freifunkh/site/pull/105.