### PR TITLE
mediatek-filogic: add kmod-ramoops package

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -167,3 +167,7 @@ end
 if target('bcm27xx') then
     packages(pkgs_hid)
 end
+
+if target('mediatek', 'filogic') then
+    packages {'kmod-ramoops'}
+end

--- a/image-customization.lua
+++ b/image-customization.lua
@@ -168,3 +168,7 @@ end
 if target('bcm27xx') then
     packages(pkgs_hid)
 end
+
+if target('mediatek', 'filogic') then
+    packages {'kmod-ramoops'}
+end


### PR DESCRIPTION
For Mediatek MT798x devices, a 64KiB `pstore` kernel memory region is declared in the .dtsi
https://github.com/openwrt/openwrt/blob/d7f9e240c208891a7d26d7a1d308cabd70618cae/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7981b.dtsi#L84-L89
to be used for retaining crash logs (ramoops) during reboot.

Add package `kmod-ramoops` (which adds `kmod-pstore` as a dependency) for the `filogic` subtarget.

Retrieval of logs currently involves manual investigation after unexpected reboots, maybe in the long term we could have a script check this on every boot (automatically send telemetry data, with user consent)?

## Example

`echo c > /proc/sysrq-trigger` will force a crash;

after reboot, check contents of `/sys/fs/pstore`:

```
root@AquilaM30Test:/# tail /sys/fs/pstore/dmesg-ramoops-0
<6>[ 1070.415231] batman_adv: bat0: Adding interface: mesh0
<6>[ 1070.420349] batman_adv: bat0: Interface activated: mesh0
<6>[ 1070.435575] batman_adv: bat0: Adding interface: mesh1
<6>[ 1070.440673] batman_adv: bat0: Interface activated: mesh1
<6>[ 1148.114556] sysrq: Trigger a crash
<0>[ 1148.117976] Kernel panic - not syncing: sysrq triggered crash
<2>[ 1148.123710] SMP: stopping secondary CPUs
<0>[ 1148.127623] Kernel Offset: disabled
<0>[ 1148.131098] CPU features: 0x0,00000000,00000000,1000400b
<0>[ 1148.136398] Memory Limit: none
root@AquilaM30Test:/# 
```

Tested on 7Links WLR-1300 and D-Link M30.